### PR TITLE
feat(AVZP-66): BING_API_KEY setting is now configurable from values.yaml

### DIFF
--- a/charts/geonode/README.md
+++ b/charts/geonode/README.md
@@ -122,6 +122,8 @@ Helm Chart for Geonode. Supported versions: Geonode: 4.4.0, Geoserver: 2.24.4-v1
 | geonode.secret.superUser.email | string | `"support@example.com"` | admin user password |
 | geonode.secret.superUser.password | string | `"geonode"` | admin panel password |
 | geonode.secret.superUser.username | string | `"admin"` | admin username |
+| geonode.secret.bing.apiKey | string | `""` | API Key for Bing Maps.  |
+| geonode.secret.django.secretKey | string | `"!^gs*4^y81)#qt1n8!#3hzd221boe3_2x+s%t9buh#qwm)q)cb"` | Django SECRET_KEY setting. It is recommended to change it prior production use. |
 | geonode.sentry.build_number | int | `0` | sentry build number |
 | geonode.sentry.dsn | string | `""` | sentry dsn url |
 | geonode.sentry.enabled | bool | `false` | enable sentry integration for geonode |

--- a/charts/geonode/templates/geonode/geonode-secret.yaml
+++ b/charts/geonode/templates/geonode/geonode-secret.yaml
@@ -23,4 +23,6 @@ data:
   OAUTH2_API_KEY: ""
   OAUTH2_CLIENT_ID: {{ .Values.geonode.secret.oauth2.clientId | b64enc }}
   OAUTH2_CLIENT_SECRET: {{ .Values.geonode.secret.oauth2.clientSecret | b64enc }}
+  SECRET_KEY: {{ .Values.geonode.secret.django.secretKey | b64enc }}
+  BING_API_KEY: {{ .Values.geonode.secret.bing.apiKey | b64enc }}
 {{ end }}

--- a/charts/geonode/values.yaml
+++ b/charts/geonode/values.yaml
@@ -63,6 +63,12 @@ geonode:
       clientId: Jrchz2oPY3akmzndmgUTYrs9gczlgoV20YPSvqaV
       # -- oauth2 geoserver secret (OAUTH2_CLIENT_SECRET)
       clientSecret: rCnp5txobUo83EpQEblM8fVj3QT5zb5qRfxNsuPzCqZaiRyIoxM4jdgMiZKFfePBHYXCLd7B8NlkfDBY9HKeIQPcy5Cp08KQNpRHQbjpLItDHv12GvkSeXp6OxaUETv3
+    bing:
+      # Bing API KEY required by MapStore to enable Bing background layers
+      apiKey: 
+    django:
+      # django SECRET_KEY setting, recommended to set custom value for production
+      secretKey: "myv-y4#7j-d*p-__@j#*3z@!y24fz8%^z2v6atuy4bo9vqr1_a"
 
   resources:
     requests:

--- a/charts/geonode/values.yaml
+++ b/charts/geonode/values.yaml
@@ -65,7 +65,7 @@ geonode:
       clientSecret: rCnp5txobUo83EpQEblM8fVj3QT5zb5qRfxNsuPzCqZaiRyIoxM4jdgMiZKFfePBHYXCLd7B8NlkfDBY9HKeIQPcy5Cp08KQNpRHQbjpLItDHv12GvkSeXp6OxaUETv3
     bing:
       # Bing API KEY required by MapStore to enable Bing background layers
-      apiKey: 
+      apiKey: ""
     django:
       # django SECRET_KEY setting, recommended to set custom value for production
       secretKey: "myv-y4#7j-d*p-__@j#*3z@!y24fz8%^z2v6atuy4bo9vqr1_a"


### PR DESCRIPTION
## Description

Currently the HELM does not allow to configure the following environment variables useful for Django Backend:
- django BING_API_KEY setting to enable tthis feature as part of MapStore
- django SECRET_KEY setting to enable secret rotation

This PR is a proposal to add these settings.

## Type of Change

New Feature

## Checklist

Please ensure that your pull request meets the following requirements:

- The pull request is limited to one type (docs, feature, bug fix, etc.)
- The pull request is as small as possible. Consider opening multiple pull requests instead of one large one.
- The feature or bug fix has been discussed and documented in an issue beforehand.

## Additional Notes

Any additional information or context regarding the pull request can be provided here.

Maybe documentation related to this feature should be improved