### PR TITLE
[Fixes #238]: "Bug: \"geonode-postgres\" is invalid: spec.postgresql.parameters.max_connections: Invalid value: \"integer\": spec.postgresql.parameters.max_connections in body must be of type string: \"integer\""

### DIFF
--- a/charts/geonode/templates/postgres/postgresql-operator.yaml
+++ b/charts/geonode/templates/postgres/postgresql-operator.yaml
@@ -39,7 +39,7 @@ spec:
         postgis: {{ .Values.postgres.schema }}
   postgresql:
     parameters:
-      max_connections: {{ .Values.postgres.operator.parameters.max_connections }}
+      max_connections: {{ .Values.postgres.operator.parameters.max_connections | quote }}
       shared_buffers: {{ .Values.postgres.operator.parameters.shared_buffers }}
       work_mem: {{ .Values.postgres.operator.parameters.work_mem }}
     version: {{ .Values.postgres.operator.postgres_version | quote }}


### PR DESCRIPTION


## Description
Fixes wrong type of `postgres.operator.parameters.max_connections` parsing to postgres operator manifest.

## Type of Change

Please select the relevant option:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Related Issue

If there is an existing issue related to this pull request, please reference it here.

closes #238 

## Checklist

Please ensure that your pull request meets the following requirements:

- The pull request is limited to one type (docs, feature, bug fix, etc.)
- The pull request is as small as possible. Consider opening multiple pull requests instead of one large one.
- The feature or bug fix has been discussed and documented in an issue beforehand.

## Additional Notes

Any additional information or context regarding the pull request can be provided here.

Thank you for creating this pull request