### PR TITLE
[Fixes #237]: "Feature: make postgres-operator manifest configuration more flexible"

### DIFF
--- a/charts/geonode/README.md
+++ b/charts/geonode/README.md
@@ -210,15 +210,15 @@ Helm Chart for Geonode. Supported versions: Geonode: 4.4.0, Geoserver: 2.24.4-v1
 | postgres.operator.enableMasterLoadBalancer | string | `nil` | boolean flag to override the operator defaults (set by the enable_master_load_balancer parameter) to define whether to enable the load balancer pointing to the Postgres primary. Optional. |
 | postgres.operator.env | list | `[]` | a dictionary of environment variables. Use usual Kubernetes definition (https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/) for environment variables. Optional. |
 | postgres.operator.numberOfInstances | int | `1` | number of database instances |
-| postgres.operator.parameters | object | `{"max_connections":"200","shared_buffers":"100Mb","work_mem":"64Mb"}` | postgres parameters resources |
+| postgres.operator.parameters | object | `{"max_connections":"20","shared_buffers":"100Mb","work_mem":"64Mb"}` | postgres parameters resources |
 | postgres.operator.patroni | object | `{}` | patroni related configuration (https://patroni.readthedocs.io/en/master/patroni_configuration.html) |
 | postgres.operator.pod_name | string | `"postgresql"` | pod name for postgres containers == teamID for mainifest |
 | postgres.operator.postgres_version | int | `15` | postgres version |
-| postgres.operator.resources | object | `{"limits":{"cpu":"400m","memory":"0.6Gi"},"requests":{"cpu":"100m","memory":"0.3Gi"}}` | Those parameters define CPU and memory requests and limits for the Postgres container. They are grouped under the resources top-level key with subgroups requests and limits |
+| postgres.operator.resources | object | `{"limits":{"cpu":"400m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"0.5Gi"}}` | Those parameters define CPU and memory requests and limits for the Postgres container. They are grouped under the resources top-level key with subgroups requests and limits |
 | postgres.operator.resources.limits.cpu | string | `"400m"` | limit cpu as in resource.requests.cpu (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
-| postgres.operator.resources.limits.memory | string | `"0.6Gi"` | limits memory as in resource.limits.memory (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| postgres.operator.resources.limits.memory | string | `"1Gi"` | limits memory as in resource.limits.memory (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | postgres.operator.resources.requests.cpu | string | `"100m"` | requested cpu as in resource.requests.cpu (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
-| postgres.operator.resources.requests.memory | string | `"0.3Gi"` | requested memory as in resource.requests.memory (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| postgres.operator.resources.requests.memory | string | `"0.5Gi"` | requested memory as in resource.requests.memory (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | postgres.operator.storageClass | string | `nil` | postgress pv storageclass |
 | postgres.operator.storageSize | string | `"3Gi"` | Database storage size |
 | postgres.schema | string | `"public"` | database schema |

--- a/charts/geonode/README.md
+++ b/charts/geonode/README.md
@@ -99,7 +99,8 @@ Helm Chart for Geonode. Supported versions: Geonode: 4.4.0, Geoserver: 2.24.4-v1
 | geonode.mail.tls | bool | `true` | activate tls for geonode mail (only tls or ssl can be true not both) |
 | geonode.mail.use_ssl | bool | `false` | enable ssl for geonode mail (only tls or ssl can be true not both) |
 | geonode.memcached.backend | string | `"django.core.cache.backends.memcached.PyLibMCCache"` | memcached backend to use if geonode ">=4.3.0" use django.core.cache.backends.memcached.PyLibMCCache before use django.core.cache.backends.memcached.MemcachedCache |
-| geonode.memcached.enabled | bool | `true` | enable memcache, this will spawn one or more seperate memcache container(s) and configure django geonode repsectivly. Dynamic caching (see https://docs.djangoproject.com/en/4.0/topics/cache/) |
+| geonode.memcached.enabled | bool | `true` | enable memcache, this will spawn one or more seperate memcache container(s) |
+| geonode.memcached.enabled_geonode | bool | `false` | set the MEMCAHED_ENABLED env var for GeoNode (django). Dynamic caching (see https://docs.djangoproject.com/en/4.0/topics/cache/) |
 | geonode.memcached.lock_expire | string | `"3600"` | memcached lock expire time |
 | geonode.memcached.lock_timeout | string | `"10"` | memcached lock timeout |
 | geonode.monitoring.centralized_dashboard_enabled | bool | `false` |  |
@@ -203,12 +204,21 @@ Helm Chart for Geonode. Supported versions: Geonode: 4.4.0, Geoserver: 2.24.4-v1
 | postgres.external.ssl | string | `"prefer"` |  |
 | postgres.geodata_databasename_and_username | string | `"geodata"` | geoserver database name and username |
 | postgres.geonode_databasename_and_username | string | `"geonode"` | geonode database name and username |
+| postgres.operator.allowedSourceRanges | list | `[]` | when one or more load balancers are enabled for the cluster, this parameter defines the comma-separated range of IP networks (in CIDR-notation). The corresponding load balancer is accessible only to the networks defined by this parameter. Optional, when empty the load balancer service becomes inaccessible from outside of the Kubernetes cluster. |
+| postgres.operator.annotations | object | `{}` | additional annotation for postgresql object |
+| postgres.operator.clone | object | `{}` |  |
+| postgres.operator.enableMasterLoadBalancer | string | `nil` | boolean flag to override the operator defaults (set by the enable_master_load_balancer parameter) to define whether to enable the load balancer pointing to the Postgres primary. Optional. |
+| postgres.operator.env | list | `[]` | a dictionary of environment variables. Use usual Kubernetes definition (https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/) for environment variables. Optional. |
 | postgres.operator.numberOfInstances | int | `1` | number of database instances |
-| postgres.operator.parameters.max_connections | int | `200` |  |
-| postgres.operator.parameters.shared_buffers | string | `"1Gb"` |  |
-| postgres.operator.parameters.work_mem | string | `"64Mb"` |  |
+| postgres.operator.parameters | object | `{"max_connections":"200","shared_buffers":"1Gb","work_mem":"64Mb"}` | postgres parameters resources |
+| postgres.operator.patroni | object | `{}` | patroni related configuration (https://patroni.readthedocs.io/en/master/patroni_configuration.html) |
 | postgres.operator.pod_name | string | `"postgresql"` | pod name for postgres containers == teamID for mainifest |
 | postgres.operator.postgres_version | int | `15` | postgres version |
+| postgres.operator.resources | object | `{"limits":{"cpu":"500m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"0.5Gi"}}` | Those parameters define CPU and memory requests and limits for the Postgres container. They are grouped under the resources top-level key with subgroups requests and limits |
+| postgres.operator.resources.limits.cpu | string | `"500m"` | limit cpu as in resource.requests.cpu (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| postgres.operator.resources.limits.memory | string | `"1Gi"` | limits memory as in resource.limits.memory (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| postgres.operator.resources.requests.cpu | string | `"100m"` | requested cpu as in resource.requests.cpu (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| postgres.operator.resources.requests.memory | string | `"0.5Gi"` | requested memory as in resource.requests.memory (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | postgres.operator.storageClass | string | `nil` | postgress pv storageclass |
 | postgres.operator.storageSize | string | `"3Gi"` | Database storage size |
 | postgres.schema | string | `"public"` | database schema |
@@ -247,4 +257,4 @@ Helm Chart for Geonode. Supported versions: Geonode: 4.4.0, Geoserver: 2.24.4-v1
 | rabbitmq.requests.memory | string | `"1Gi"` | requested memory as in resource.requests.memory (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 
 ----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.13.1](https://github.com/norwoodj/helm-docs/releases/v1.13.1)
+Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)

--- a/charts/geonode/README.md
+++ b/charts/geonode/README.md
@@ -210,15 +210,15 @@ Helm Chart for Geonode. Supported versions: Geonode: 4.4.0, Geoserver: 2.24.4-v1
 | postgres.operator.enableMasterLoadBalancer | string | `nil` | boolean flag to override the operator defaults (set by the enable_master_load_balancer parameter) to define whether to enable the load balancer pointing to the Postgres primary. Optional. |
 | postgres.operator.env | list | `[]` | a dictionary of environment variables. Use usual Kubernetes definition (https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/) for environment variables. Optional. |
 | postgres.operator.numberOfInstances | int | `1` | number of database instances |
-| postgres.operator.parameters | object | `{"max_connections":"200","shared_buffers":"1Gb","work_mem":"64Mb"}` | postgres parameters resources |
+| postgres.operator.parameters | object | `{"max_connections":"200","shared_buffers":"100Mb","work_mem":"64Mb"}` | postgres parameters resources |
 | postgres.operator.patroni | object | `{}` | patroni related configuration (https://patroni.readthedocs.io/en/master/patroni_configuration.html) |
 | postgres.operator.pod_name | string | `"postgresql"` | pod name for postgres containers == teamID for mainifest |
 | postgres.operator.postgres_version | int | `15` | postgres version |
-| postgres.operator.resources | object | `{"limits":{"cpu":"500m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"0.5Gi"}}` | Those parameters define CPU and memory requests and limits for the Postgres container. They are grouped under the resources top-level key with subgroups requests and limits |
-| postgres.operator.resources.limits.cpu | string | `"500m"` | limit cpu as in resource.requests.cpu (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
-| postgres.operator.resources.limits.memory | string | `"1Gi"` | limits memory as in resource.limits.memory (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| postgres.operator.resources | object | `{"limits":{"cpu":"400m","memory":"0.6Gi"},"requests":{"cpu":"100m","memory":"0.3Gi"}}` | Those parameters define CPU and memory requests and limits for the Postgres container. They are grouped under the resources top-level key with subgroups requests and limits |
+| postgres.operator.resources.limits.cpu | string | `"400m"` | limit cpu as in resource.requests.cpu (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| postgres.operator.resources.limits.memory | string | `"0.6Gi"` | limits memory as in resource.limits.memory (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | postgres.operator.resources.requests.cpu | string | `"100m"` | requested cpu as in resource.requests.cpu (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
-| postgres.operator.resources.requests.memory | string | `"0.5Gi"` | requested memory as in resource.requests.memory (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| postgres.operator.resources.requests.memory | string | `"0.3Gi"` | requested memory as in resource.requests.memory (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | postgres.operator.storageClass | string | `nil` | postgress pv storageclass |
 | postgres.operator.storageSize | string | `"3Gi"` | Database storage size |
 | postgres.schema | string | `"public"` | database schema |

--- a/charts/geonode/README.md
+++ b/charts/geonode/README.md
@@ -210,7 +210,7 @@ Helm Chart for Geonode. Supported versions: Geonode: 4.4.0, Geoserver: 2.24.4-v1
 | postgres.operator.enableMasterLoadBalancer | string | `nil` | boolean flag to override the operator defaults (set by the enable_master_load_balancer parameter) to define whether to enable the load balancer pointing to the Postgres primary. Optional. |
 | postgres.operator.env | list | `[]` | a dictionary of environment variables. Use usual Kubernetes definition (https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/) for environment variables. Optional. |
 | postgres.operator.numberOfInstances | int | `1` | number of database instances |
-| postgres.operator.parameters | object | `{"max_connections":"20","shared_buffers":"100Mb","work_mem":"64Mb"}` | postgres parameters resources |
+| postgres.operator.parameters | object | `{"max_connections":"20","shared_buffers":"250MB","work_mem":"12.5Mb"}` | postgres parameters resources |
 | postgres.operator.patroni | object | `{}` | patroni related configuration (https://patroni.readthedocs.io/en/master/patroni_configuration.html) |
 | postgres.operator.pod_name | string | `"postgresql"` | pod name for postgres containers == teamID for mainifest |
 | postgres.operator.postgres_version | int | `15` | postgres version |

--- a/charts/geonode/templates/postgres/postgresql-operator.yaml
+++ b/charts/geonode/templates/postgres/postgresql-operator.yaml
@@ -4,11 +4,21 @@ apiVersion: "acid.zalan.do/v1"
 kind: postgresql
 metadata:
   name: "{{ include "postgres_pod_name" . }}"
+  {{- if .Values.postgres.operator.annotations }}
+  annotations:
+    {{- toYaml .Values.postgres.operator.annotations | nindent 4 }}
+  {{- end }}
 spec:
+  {{ if .Values.postgres.operator.env }}
+  env:
+    {{- toYaml .Values.postgres.operator.env | nindent 4 }}
+  {{- end }}
   teamId: {{ .Release.Name | quote }}
   volume:
     size: {{ .Values.postgres.operator.storageSize }}
     storageClass: {{ .Values.postgres.operator.storageClass }}
+  enableMasterLoadBalancer: {{ .Values.postgres.operator.enableMasterLoadBalancer }}
+  allowedSourceRanges: {{- toYaml .Values.postgres.operator.allowedSourceRanges | nindent 4 }}
   numberOfInstances: {{ int .Values.postgres.operator.numberOfInstances }}
   users:
     {{ .Values.postgres.username }}:
@@ -38,9 +48,16 @@ spec:
         pg_partman: {{ .Values.postgres.schema }}
         postgis: {{ .Values.postgres.schema }}
   postgresql:
-    parameters:
-      max_connections: {{ .Values.postgres.operator.parameters.max_connections | quote }}
-      shared_buffers: {{ .Values.postgres.operator.parameters.shared_buffers }}
-      work_mem: {{ .Values.postgres.operator.parameters.work_mem }}
+    {{- if .Values.postgres.operator.parameters }}
+    parameters: {{- toYaml .Values.postgres.operator.parameters | nindent 6 }}
+    {{- end }}
     version: {{ .Values.postgres.operator.postgres_version | quote }}
+
+  {{- if .Values.postgres.operator.patroni }}
+  patroni: {{- toYaml .Values.postgres.operator.patroni | nindent 4 }}
+  {{- end }}
+  resources: {{ toYaml .Values.postgres.operator.resources | nindent 4 }}
+  {{- if .Values.postgres.operator.clone }}
+  clone: {{- toYaml .Values.postgres.operator.clone | nindent 4 }}
+  {{- end }}
 {{ end }}

--- a/charts/geonode/templates/postgres/postgresql-operator.yaml
+++ b/charts/geonode/templates/postgres/postgresql-operator.yaml
@@ -52,7 +52,6 @@ spec:
     parameters: {{- toYaml .Values.postgres.operator.parameters | nindent 6 }}
     {{- end }}
     version: {{ .Values.postgres.operator.postgres_version | quote }}
-
   {{- if .Values.postgres.operator.patroni }}
   patroni: {{- toYaml .Values.postgres.operator.patroni | nindent 4 }}
   {{- end }}

--- a/charts/geonode/values.yaml
+++ b/charts/geonode/values.yaml
@@ -707,7 +707,7 @@ postgres:
     # -- postgres parameters resources
     parameters:
       max_connections: "200"
-      shared_buffers: 1Gb
+      shared_buffers: 100Mb
       work_mem: 64Mb
     # --
     clone: {}
@@ -715,14 +715,14 @@ postgres:
     resources:
       requests:
         # -- requested memory as in resource.requests.memory (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
-        memory: "0.5Gi"
+        memory: "0.3Gi"
         # -- requested cpu as in resource.requests.cpu (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
         cpu: "100m"
       limits:
         # -- limits memory as in resource.limits.memory (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
-        memory: "1Gi"
+        memory: "0.6Gi"
         # -- limit cpu as in resource.requests.cpu (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
-        cpu: "500m"
+        cpu: "400m"
 
   external:
     hostname: my-external-postgres.com

--- a/charts/geonode/values.yaml
+++ b/charts/geonode/values.yaml
@@ -706,7 +706,7 @@ postgres:
     patroni: {}
     # -- postgres parameters resources
     parameters:
-      max_connections: "200"
+      max_connections: "20"
       shared_buffers: 100Mb
       work_mem: 64Mb
     # --
@@ -715,12 +715,12 @@ postgres:
     resources:
       requests:
         # -- requested memory as in resource.requests.memory (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
-        memory: "0.3Gi"
+        memory: "0.5Gi"
         # -- requested cpu as in resource.requests.cpu (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
         cpu: "100m"
       limits:
         # -- limits memory as in resource.limits.memory (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
-        memory: "0.6Gi"
+        memory: "1Gi"
         # -- limit cpu as in resource.requests.cpu (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
         cpu: "400m"
 

--- a/charts/geonode/values.yaml
+++ b/charts/geonode/values.yaml
@@ -679,7 +679,7 @@ postgres:
   # -- geoserver database name and username
   geodata_databasename_and_username: geodata
 
-  # configuration for postgres operator database manifest
+  # configuration for postgres operator database manifest (https://github.com/zalando/postgres-operator/blob/master/docs/reference/cluster_manifest.md)
   operator:
     # -- pod name for postgres containers == teamID for mainifest
     pod_name: postgresql
@@ -691,13 +691,39 @@ postgres:
     numberOfInstances: 1
     # -- postgres version
     postgres_version: 15
-    # database passwords are set randomly
-    # infos @ https://postgres-operator.readthedocs.io/en/refactoring-sidecars/user/
-    # get password after creation via: kubectl get secret {{ .Release.name }}.{{ .Release.name }}-{{ container_name }}.credentials -o 'jsonpath={.data.password}' | base64 -d
+    # -- boolean flag to override the operator defaults (set by the enable_master_load_balancer parameter) to define whether to enable the load balancer pointing to the Postgres primary. Optional.
+    enableMasterLoadBalancer:
+    # -- when one or more load balancers are enabled for the cluster, this parameter defines the comma-separated range of IP networks (in CIDR-notation).
+    # The corresponding load balancer is accessible only to the networks defined by this parameter.
+    # Optional, when empty the load balancer service becomes inaccessible from outside of the Kubernetes cluster.
+    allowedSourceRanges: []
+    # -- a dictionary of environment variables. Use usual Kubernetes definition (https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/)
+    # for environment variables. Optional.
+    env: []
+    # -- additional annotation for postgresql object
+    annotations: {}
+    # -- patroni related configuration (https://patroni.readthedocs.io/en/master/patroni_configuration.html)
+    patroni: {}
+    # -- postgres parameters resources
     parameters:
-      max_connections: 200
+      max_connections: "200"
       shared_buffers: 1Gb
       work_mem: 64Mb
+    # --
+    clone: {}
+    # -- Those parameters define CPU and memory requests and limits for the Postgres container. They are grouped under the resources top-level key with subgroups requests and limits
+    resources:
+      requests:
+        # -- requested memory as in resource.requests.memory (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+        memory: "0.5Gi"
+        # -- requested cpu as in resource.requests.cpu (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+        cpu: "100m"
+      limits:
+        # -- limits memory as in resource.limits.memory (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+        memory: "1Gi"
+        # -- limit cpu as in resource.requests.cpu (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+        cpu: "500m"
+
   external:
     hostname: my-external-postgres.com
     port: 5432

--- a/charts/geonode/values.yaml
+++ b/charts/geonode/values.yaml
@@ -707,8 +707,8 @@ postgres:
     # -- postgres parameters resources
     parameters:
       max_connections: "20"
-      shared_buffers: 100Mb
-      work_mem: 64Mb
+      shared_buffers: 250MB
+      work_mem: 12.5Mb
     # --
     clone: {}
     # -- Those parameters define CPU and memory requests and limits for the Postgres container. They are grouped under the resources top-level key with subgroups requests and limits


### PR DESCRIPTION
## Description

Extending available configuration features for postgres operator manifest, basically to allow users to configure postgres manifest to enable backups.

## Type of Change

Please select the relevant option:

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [x] Refactoring
- [ ] Other (please describe)

## Related Issue

If there is an existing issue related to this pull request, please reference it here.

closes #237

## Checklist

Please ensure that your pull request meets the following requirements:

- The pull request is limited to one type (docs, feature, bug fix, etc.)
- The pull request is as small as possible. Consider opening multiple pull requests instead of one large one.
- The feature or bug fix has been discussed and documented in an issue beforehand.

## Additional Notes

Any additional information or context regarding the pull request can be provided here.

Thank you for creating this pull request