### PR TITLE
[Fixes #251]: "Feature: Improve GeoNode container start time"

### DIFF
--- a/charts/geonode/README.md
+++ b/charts/geonode/README.md
@@ -129,7 +129,6 @@ Helm Chart for Geonode. Supported versions: Geonode: 4.4.3, Geoserver: 2.24.4-la
 | geonode.sentry.enabled | bool | `false` | enable sentry integration for geonode |
 | geonode.sentry.environment | string | `"development"` | sentry environment |
 | geonode.startupProbe | object | `{"failureThreshold":12,"httpGet":{"path":"/","port":"http-monitor"},"periodSeconds":10}` | configure startupProbe for geonode, make sure port is aligned with geonode.port configuration |
-| geonode.tasks_post_script | string | `"print(\"tasks_post_script not defined ...\")\n"` | additions to tasks.py script at the beginning of the tasks.py, must be additional code written in python |
 | geonode.tasks_pre_script | string | `"print(\"tasks_pre_script not defined ...\")\n"` | additions to tasks.py init script, must be additional code written in python |
 | geonode.uwsgi.buffer_size | int | `32768` | the max size of a request (request-body excluded) |
 | geonode.uwsgi.cheaper | int | `2` | Minimum number of workers allowed |

--- a/charts/geonode/README.md
+++ b/charts/geonode/README.md
@@ -122,7 +122,7 @@ Helm Chart for Geonode. Supported versions: Geonode: 4.4.3, Geoserver: 2.24.4-la
 | geonode.secret.oauth2.clientId | string | `"Jrchz2oPY3akmzndmgUTYrs9gczlgoV20YPSvqaV"` | oauth2 geoserver clientID (OAUTH2_CLIENT_ID) |
 | geonode.secret.oauth2.clientSecret | string | `"rCnp5txobUo83EpQEblM8fVj3QT5zb5qRfxNsuPzCqZaiRyIoxM4jdgMiZKFfePBHYXCLd7B8NlkfDBY9HKeIQPcy5Cp08KQNpRHQbjpLItDHv12GvkSeXp6OxaUETv3"` | oauth2 geoserver secret (OAUTH2_CLIENT_SECRET) |
 | geonode.secret.superUser.email | string | `"support@example.com"` | admin user password |
-| geonode.secret.superUser.password | string | `"geonode"` | admin panel password |
+| geonode.secret.superUser.password | string | `"geonode"` | admin panel password, will only changed after running the init-db job. At first time deployment or after rerunning the job manually. (See docs/manage-py-jobs.md) |
 | geonode.secret.superUser.username | string | `"admin"` | admin username |
 | geonode.sentry.build_number | int | `0` | sentry build number |
 | geonode.sentry.dsn | string | `""` | sentry dsn url |

--- a/charts/geonode/README.md
+++ b/charts/geonode/README.md
@@ -122,7 +122,7 @@ Helm Chart for Geonode. Supported versions: Geonode: 4.4.3, Geoserver: 2.24.4-la
 | geonode.secret.oauth2.clientId | string | `"Jrchz2oPY3akmzndmgUTYrs9gczlgoV20YPSvqaV"` | oauth2 geoserver clientID (OAUTH2_CLIENT_ID) |
 | geonode.secret.oauth2.clientSecret | string | `"rCnp5txobUo83EpQEblM8fVj3QT5zb5qRfxNsuPzCqZaiRyIoxM4jdgMiZKFfePBHYXCLd7B8NlkfDBY9HKeIQPcy5Cp08KQNpRHQbjpLItDHv12GvkSeXp6OxaUETv3"` | oauth2 geoserver secret (OAUTH2_CLIENT_SECRET) |
 | geonode.secret.superUser.email | string | `"support@example.com"` | admin user password |
-| geonode.secret.superUser.password | string | `"geonode"` | admin panel password, will only changed after running the init-db job. At first time deployment or after rerunning the job manually. (See docs/manage-py-jobs.md) |
+| geonode.secret.superUser.password | string | `"geonode"` | admin panel password, will only be changed after running the init-db job. At first time deployment or after rerunning the job manually. (See docs/manage-py-jobs.md) |
 | geonode.secret.superUser.username | string | `"admin"` | admin username |
 | geonode.sentry.build_number | int | `0` | sentry build number |
 | geonode.sentry.dsn | string | `""` | sentry dsn url |

--- a/charts/geonode/templates/geonode/geonode-deploy.yaml
+++ b/charts/geonode/templates/geonode/geonode-deploy.yaml
@@ -57,11 +57,6 @@ spec:
         - bash
         - -c
         - |
-          # install dockerize...
-          wget -q https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-            && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-            && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-
           {{ if .Values.geonode.ldap.enabled }}
           # install geonode ldap contrib if ldap enabled. it would be better to have a base model with ldap included,
           # but this way we can build the vanilla Dockerfile from geonode/geonode
@@ -77,12 +72,7 @@ spec:
           cat /usr/src/geonode/geonode/geonode-k8s-settings-additions.py >> {{ include "geonode_path" .}}/settings.py
 
           # Setup
-          touch {{ include "geonode_root_path" .}}/invoke.log
-          dockerize -stdout {{ include "geonode_root_path" .}}/invoke.log {{ include "geonode_root_path" .}}/entrypoint.sh
-
-          # Run web server
-          touch /var/log/geonode.log
-          dockerize -stdout /var/log/geonode.log /usr/local/bin/uwsgi --ini {{ include "geonode_root_path" .}}/uwsgi.ini
+          {{ include "geonode_root_path" .}}/entrypoint.sh /usr/local/bin/uwsgi --ini {{ include "geonode_root_path" .}}/uwsgi.ini
 
         ports:
         - name: http
@@ -173,11 +163,6 @@ spec:
         - bash
         - -c
         - |
-          # install dockerize...
-          wget -q https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-            && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-            && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-
           {{ if .Values.geonode.ldap.enabled }}
           # install geonode ldap contrib if ldap enabled. it would be better to have a base model with ldap included,
           # but this way we can build the vanilla Dockerfile from geonode/geonode.
@@ -198,7 +183,7 @@ spec:
           cat /usr/src/geonode/geonode/geonode-k8s-settings-additions.py >> {{ include "geonode_path" .}}/settings.py
           # Setup
           touch /var/log/celery.log
-          dockerize -stdout /var/log/celery.log {{ include "geonode_root_path" .}}/entrypoint.sh celery-cmd
+          {{ include "geonode_root_path" .}}/entrypoint.sh celery-cmd
 
         envFrom:
         - configMapRef:

--- a/charts/geonode/templates/geonode/geonode-entrypoint-sh-conf.yaml
+++ b/charts/geonode/templates/geonode/geonode-entrypoint-sh-conf.yaml
@@ -45,8 +45,8 @@ data:
     echo MONITORING_HOST_NAME=$MONITORING_HOST_NAME
     echo MONITORING_SERVICE_NAME=$MONITORING_SERVICE_NAME
     echo MONITORING_DATA_TTL=$MONITORING_DATA_TTL
-    # deactivated until https://github.com/GeoNode/geonode/pull/11340 is merged
-    #invoke waitfordbs
+    # database must run on port 5432
+    invoke waitfordbs
 
     cmd="$@"
 
@@ -55,21 +55,6 @@ data:
         echo "Executing Celery server $cmd for Production"
     else
         invoke prescript
-        invoke migrations
-        invoke prepare
-
-        if [ ${FORCE_REINIT} = "true" ]  || [ ${FORCE_REINIT} = "True" ] || [ ! -e "/mnt/volumes/statics/geonode_init.lock" ]; then
-            invoke updategeoip
-            invoke fixtures
-            # currently not implemented in geonode-k8s
-            # invoke monitoringfixture
-            invoke initialized
-            invoke updateadmin
-        fi
-
-        invoke statics
-        invoke waitforgeoserver
-        invoke geoserverfixture
         invoke postscript
         echo "Executing UWSGI server $cmd for Production"
     fi

--- a/charts/geonode/templates/geonode/geonode-entrypoint-sh-conf.yaml
+++ b/charts/geonode/templates/geonode/geonode-entrypoint-sh-conf.yaml
@@ -55,7 +55,6 @@ data:
         echo "Executing Celery server $cmd for Production"
     else
         invoke prescript
-        invoke postscript
         echo "Executing UWSGI server $cmd for Production"
     fi
 

--- a/charts/geonode/templates/geonode/geonode-env.yaml
+++ b/charts/geonode/templates/geonode/geonode-env.yaml
@@ -10,7 +10,6 @@ data:
   IS_CELERY: "False"
   CELERY_BEAT_SCHEDULER: "celery.beat:PersistentScheduler"
 
-  DOCKERIZE_VERSION: "v0.6.1"
   DEBUG: {{ include "boolean2str" .Values.geonode.general.debug | quote }}
   DEBUG_STATIC: {{ include "boolean2str" .Values.geonode.general.debug_static | quote }}
 

--- a/charts/geonode/templates/geonode/geonode-tasks-py-conf.yaml
+++ b/charts/geonode/templates/geonode/geonode-tasks-py-conf.yaml
@@ -429,11 +429,6 @@ data:
         print("**********************geonode-k8s pre ***************************")
         {{ .Values.geonode.tasks_pre_script | indent 8 | trim }}
 
-    @task
-    def postscript(ctx):
-        print("**********************geonode-k8s post ***************************")
-        {{ .Values.geonode.tasks_post_script | indent 8 | trim }}
-
 
     def _update_db_connstring():
         user = os.getenv('GEONODE_DATABASE', 'geonode')

--- a/charts/geonode/templates/geonode/jobs/geonode-init-db-job.yaml
+++ b/charts/geonode/templates/geonode/jobs/geonode-init-db-job.yaml
@@ -1,0 +1,163 @@
+# check if postgres.type is set to external operator
+{{ $is_operator := (eq .Values.postgres.type "operator") }}
+{{ $is_external := (eq .Values.postgres.type "external") }}
+{{ if not (or $is_operator  $is_external) }}
+  {{- fail "Deploymnent FAILED, unknown postgres.type defined, please set postgres.type to operator or external ..." }}
+{{ end }}
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ include "geonode_pod_name" . }}-init-db-job"
+  namespace: {{ .Release.Namespace }}
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        org.geonode.instance: "{{ include "geonode_pod_name" . }}-init-db-job"
+    spec:
+{{- if not (empty .Values.geonode.imagePullSecret) }}
+      imagePullSecrets:
+      - name: {{ .Values.geonode.imagePullSecret }}
+{{ end }}
+      restartPolicy: OnFailure
+      initContainers:
+      # Wait for Postgres and rabbit
+      - name: {{ .Values.geonode.init.container_name }}-init-db-job
+        image: "{{ .Values.geonode.init.image.name }}:{{ .Values.geonode.init.image.tag }}"
+        imagePullPolicy: {{ .Values.geonode.init.imagePullPolicy }}
+        args:
+        - -timeout=60s
+        - -wait
+        - tcp://{{ include "database_hostname" . }}:{{ include "database_port" . }}
+        - -wait
+        - tcp://{{ include "rabbit_host" .}}
+
+      containers:
+      - name: {{ .Values.geonode.container_name }}-init-db-job
+        image: "{{ .Values.geonode.image.name }}:{{ .Values.geonode.image.tag }}"
+        imagePullPolicy: {{ .Values.geonode.imagePullPolicy }}
+        command:
+        - bash
+        - -c
+        - |
+          # install dockerize...
+          wget -q https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+          && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+          && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+          {{ if .Values.geonode.ldap.enabled }}
+          # install geonode ldap contrib if ldap enabled. it would be better to have a base model with ldap included,
+          # but this way we can build the vanilla Dockerfile from geonode/geonode
+
+          cd /usr/src; git clone https://github.com/GeoNode/geonode-contribs.git -b master
+          cd /usr/src/geonode-contribs/ldap; pip install --upgrade  -e .
+          cd /usr/src/geonode/
+          {{ end }}
+
+          cd {{ include "geonode_root_path" .}}/
+          # Add config overrides
+          cat /usr/src/geonode/geonode/geonode-k8s-settings.py >> {{ include "geonode_path" .}}/settings.py
+          cat /usr/src/geonode/geonode/geonode-k8s-settings-additions.py >> {{ include "geonode_path" .}}/settings.py
+
+          echo "-----------------------------------------------------"
+          echo "Starting Geonode migration tasks (waitfordbs, migrations) $(date)"
+          echo "-----------------------------------------------------"
+          invoke waitfordbs
+          invoke migrations
+          echo "-----------------------------------------------------"
+          echo "Geonode migration tasks done $(date)"
+          echo "-----------------------------------------------------"
+
+          echo "-----------------------------------------------------"
+          echo "Starting Geonode fixture tasks (prepare, fixtures, waitforgeoserver, geoserverfixture) $(date)"
+          echo "-----------------------------------------------------"
+          # insert fixtures for geonode into database
+          invoke prepare
+          invoke fixtures
+          # create geoserver store
+          invoke waitforgeoserver
+          invoke geoserverfixture
+          echo "-----------------------------------------------------"
+          echo "Geonode fixture tasks done $(date)"
+          echo "-----------------------------------------------------"
+          echo "-----------------------------------------------------"
+          echo "Starting Geonode set admin password tasks (updateadmin) $(date)"
+          echo "-----------------------------------------------------"
+          invoke updateadmin
+          echo "-----------------------------------------------------"
+          echo "Geonode set admin password tasks done $(date)"
+          echo "-----------------------------------------------------"
+        envFrom:
+        - configMapRef:
+            name: {{ include "geonode_pod_name" . }}-env
+        - secretRef:
+            name: {{ .Values.geonode.secret.existingSecretName | default (include "geonode_secret_name" .) | quote }}
+        - secretRef:
+            name: {{ .Values.geoserver.secret.existingSecretName | default (include "geoserver_secret_name" .) | quote }}
+        env:
+        - name: GEONODE_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "database_geonode_password_secret_key_ref" . }}
+              key: {{ include "database_geonode_password_key_ref" . }}
+        - name: GEONODE_GEODATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "database_geodata_password_secret_key_ref" . }}
+              key: {{ include "database_geodata_password_key_ref" . }}
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "database_postgres_password_secret_key_ref" . }}
+              key: {{ include "database_postgres_password_key_ref" . }}
+        - name: GEODATABASE_URL
+          value: "postgis://$(GEONODE_GEODATABASE):$(GEONODE_GEODATABASE_PASSWORD)@$(DATABASE_HOST):$(DATABASE_PORT)/$(GEONODE_GEODATABASE)"
+        - name: DATABASE_URL
+          value: "postgis://$(GEONODE_DATABASE):$(GEONODE_DATABASE_PASSWORD)@$(DATABASE_HOST):$(DATABASE_PORT)/$(GEONODE_DATABASE)"
+        volumeMounts:
+        - name: "{{ include "persistant_volume_name" . }}"
+          mountPath: /data
+          subPath: data
+        - name: cache-volume
+          mountPath: /tmp
+        - name: tasks-py
+          mountPath: "{{ include "geonode_root_path" .}}/tasks.py"
+          subPath: tasks.py
+          readOnly: true
+        - name: geonode-k8s-settings-py
+          mountPath: "/usr/src/geonode/geonode/geonode-k8s-settings.py"
+          subPath: geonode-k8s-settings.py
+        - name: geonode-k8s-settings-additions-py
+          mountPath: "/usr/src/geonode/geonode/geonode-k8s-settings-additions.py"
+          subPath: geonode-k8s-settings-additions.py
+          readOnly: true
+      volumes:
+      - name: "{{ include "persistant_volume_name" . }}"
+        persistentVolumeClaim:
+          claimName: pvc-{{ .Release.Name }}-geonode
+      - name: tasks-py
+        configMap:
+          name: {{ .Release.Name }}-geonode-tasks-py
+          items:
+          - key: tasks.py
+            path: "tasks.py"
+      - name: geonode-k8s-settings-py
+        configMap:
+          name: {{ .Release.Name }}-geonode-k8s-settings-py
+          defaultMode: 0744
+          items:
+          - key: geonode-k8s-settings.py
+            path: "geonode-k8s-settings.py"
+      - name: geonode-k8s-settings-additions-py
+        configMap:
+          name: {{ .Release.Name }}-geonode-k8s-settings-additions-py
+          defaultMode: 0744
+          items:
+          - key: geonode-k8s-settings-additions.py
+            path: "geonode-k8s-settings-additions.py"
+
+      # Using an emptyDir to cache compiled statics... it will survive container crashes, but not pod restarts
+      - name: cache-volume
+        emptyDir: {}

--- a/charts/geonode/templates/geonode/jobs/geonode-init-db-job.yaml
+++ b/charts/geonode/templates/geonode/jobs/geonode-init-db-job.yaml
@@ -42,20 +42,6 @@ spec:
         - bash
         - -c
         - |
-          # install dockerize...
-          wget -q https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-          && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-          && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-
-          {{ if .Values.geonode.ldap.enabled }}
-          # install geonode ldap contrib if ldap enabled. it would be better to have a base model with ldap included,
-          # but this way we can build the vanilla Dockerfile from geonode/geonode
-
-          cd /usr/src; git clone https://github.com/GeoNode/geonode-contribs.git -b master
-          cd /usr/src/geonode-contribs/ldap; pip install --upgrade  -e .
-          cd /usr/src/geonode/
-          {{ end }}
-
           cd {{ include "geonode_root_path" .}}/
           # Add config overrides
           cat /usr/src/geonode/geonode/geonode-k8s-settings.py >> {{ include "geonode_path" .}}/settings.py

--- a/charts/geonode/templates/geonode/jobs/geonode-init-db-job.yaml
+++ b/charts/geonode/templates/geonode/jobs/geonode-init-db-job.yaml
@@ -42,6 +42,7 @@ spec:
         - bash
         - -c
         - |
+          set -e
           cd {{ include "geonode_root_path" .}}/
           # Add config overrides
           cat /usr/src/geonode/geonode/geonode-k8s-settings.py >> {{ include "geonode_path" .}}/settings.py

--- a/charts/geonode/templates/geonode/jobs/geonode-statics-job.yaml
+++ b/charts/geonode/templates/geonode/jobs/geonode-statics-job.yaml
@@ -30,11 +30,6 @@ spec:
         - bash
         - -c
         - |
-          # install dockerize...
-          wget -q https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-          && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-          && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-
           {{ if .Values.geonode.ldap.enabled }}
           # install geonode ldap contrib if ldap enabled. it would be better to have a base model with ldap included,
           # but this way we can build the vanilla Dockerfile from geonode/geonode

--- a/charts/geonode/templates/geonode/jobs/geonode-statics-job.yaml
+++ b/charts/geonode/templates/geonode/jobs/geonode-statics-job.yaml
@@ -1,0 +1,134 @@
+# check if postgres.type is set to external operator
+{{ $is_operator := (eq .Values.postgres.type "operator") }}
+{{ $is_external := (eq .Values.postgres.type "external") }}
+{{ if not (or $is_operator  $is_external) }}
+  {{- fail "Deploymnent FAILED, unknown postgres.type defined, please set postgres.type to operator or external ..." }}
+{{ end }}
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ include "geonode_pod_name" . }}-statics-job"
+  namespace: {{ .Release.Namespace }}
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        org.geonode.instance: "{{ include "geonode_pod_name" . }}-statics-job"
+    spec:
+{{- if not (empty .Values.geonode.imagePullSecret) }}
+      imagePullSecrets:
+      - name: {{ .Values.geonode.imagePullSecret }}
+{{ end }}
+      restartPolicy: OnFailure
+      containers:
+      - name: {{ .Values.geonode.container_name }}-statics-job
+        image: "{{ .Values.geonode.image.name }}:{{ .Values.geonode.image.tag }}"
+        imagePullPolicy: {{ .Values.geonode.imagePullPolicy }}
+        command:
+        - bash
+        - -c
+        - |
+          # install dockerize...
+          wget -q https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+          && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+          && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+          {{ if .Values.geonode.ldap.enabled }}
+          # install geonode ldap contrib if ldap enabled. it would be better to have a base model with ldap included,
+          # but this way we can build the vanilla Dockerfile from geonode/geonode
+
+          cd /usr/src; git clone https://github.com/GeoNode/geonode-contribs.git -b master
+          cd /usr/src/geonode-contribs/ldap; pip install --upgrade  -e .
+          cd /usr/src/geonode/
+          {{ end }}
+
+          cd {{ include "geonode_root_path" .}}/
+          # Add config overrides
+          cat /usr/src/geonode/geonode/geonode-k8s-settings.py >> {{ include "geonode_path" .}}/settings.py
+          cat /usr/src/geonode/geonode/geonode-k8s-settings-additions.py >> {{ include "geonode_path" .}}/settings.py
+
+          echo "-----------------------------------------------------"
+          echo "Starting GeoNode static tasks (migrations) $(date)"
+          echo "-----------------------------------------------------"
+          invoke initialized
+          invoke statics
+          echo "-----------------------------------------------------"
+          echo "GeoNode static tasks done $(date)"
+          echo "-----------------------------------------------------"
+        envFrom:
+        - configMapRef:
+            name: {{ include "geonode_pod_name" . }}-env
+        - secretRef:
+            name: {{ .Values.geonode.secret.existingSecretName | default (include "geonode_secret_name" .) | quote }}
+        - secretRef:
+            name: {{ .Values.geoserver.secret.existingSecretName | default (include "geoserver_secret_name" .) | quote }}
+        env:
+        - name: GEONODE_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "database_geonode_password_secret_key_ref" . }}
+              key: {{ include "database_geonode_password_key_ref" . }}
+        - name: GEONODE_GEODATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "database_geodata_password_secret_key_ref" . }}
+              key: {{ include "database_geodata_password_key_ref" . }}
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "database_postgres_password_secret_key_ref" . }}
+              key: {{ include "database_postgres_password_key_ref" . }}
+        - name: GEODATABASE_URL
+          value: "postgis://$(GEONODE_GEODATABASE):$(GEONODE_GEODATABASE_PASSWORD)@$(DATABASE_HOST):$(DATABASE_PORT)/$(GEONODE_GEODATABASE)"
+        - name: DATABASE_URL
+          value: "postgis://$(GEONODE_DATABASE):$(GEONODE_DATABASE_PASSWORD)@$(DATABASE_HOST):$(DATABASE_PORT)/$(GEONODE_DATABASE)"
+        volumeMounts:
+        - name: "{{ include "persistant_volume_name" . }}"
+          mountPath: /data
+          subPath: data
+        - name: cache-volume
+          mountPath: /tmp
+        - name: tasks-py
+          mountPath: "{{ include "geonode_root_path" .}}/tasks.py"
+          subPath: tasks.py
+          readOnly: true
+        - name: geonode-k8s-settings-py
+          mountPath: "/usr/src/geonode/geonode/geonode-k8s-settings.py"
+          subPath: geonode-k8s-settings.py
+        - name: geonode-k8s-settings-additions-py
+          mountPath: "/usr/src/geonode/geonode/geonode-k8s-settings-additions.py"
+          subPath: geonode-k8s-settings-additions.py
+          readOnly: true
+        - name: "{{ include "persistant_volume_name" . }}"
+          mountPath: /mnt/volumes/statics
+          subPath: statics
+      volumes:
+      - name: "{{ include "persistant_volume_name" . }}"
+        persistentVolumeClaim:
+          claimName: pvc-{{ .Release.Name }}-geonode
+      - name: tasks-py
+        configMap:
+          name: {{ .Release.Name }}-geonode-tasks-py
+          items:
+          - key: tasks.py
+            path: "tasks.py"
+      - name: geonode-k8s-settings-py
+        configMap:
+          name: {{ .Release.Name }}-geonode-k8s-settings-py
+          defaultMode: 0744
+          items:
+          - key: geonode-k8s-settings.py
+            path: "geonode-k8s-settings.py"
+      - name: geonode-k8s-settings-additions-py
+        configMap:
+          name: {{ .Release.Name }}-geonode-k8s-settings-additions-py
+          defaultMode: 0744
+          items:
+          - key: geonode-k8s-settings-additions.py
+            path: "geonode-k8s-settings-additions.py"
+
+      # Using an emptyDir to cache compiled statics... it will survive container crashes, but not pod restarts
+      - name: cache-volume
+        emptyDir: {}

--- a/charts/geonode/templates/geonode/jobs/geonode-statics-job.yaml
+++ b/charts/geonode/templates/geonode/jobs/geonode-statics-job.yaml
@@ -30,6 +30,7 @@ spec:
         - bash
         - -c
         - |
+          set -e
           {{ if .Values.geonode.ldap.enabled }}
           # install geonode ldap contrib if ldap enabled. it would be better to have a base model with ldap included,
           # but this way we can build the vanilla Dockerfile from geonode/geonode

--- a/charts/geonode/values.yaml
+++ b/charts/geonode/values.yaml
@@ -45,7 +45,7 @@ geonode:
     superUser:
       # -- admin username
       username: admin
-      # -- admin panel password
+      # -- admin panel password, will only changed after running the init-db job. At first time deployment or after rerunning the job manually. (See docs/manage-py-jobs.md)
       password: geonode
       # -- admin user password
       email: support@example.com

--- a/charts/geonode/values.yaml
+++ b/charts/geonode/values.yaml
@@ -42,7 +42,7 @@ geonode:
     superUser:
       # -- admin username
       username: admin
-      # -- admin panel password, will only changed after running the init-db job. At first time deployment or after rerunning the job manually. (See docs/manage-py-jobs.md)
+      # -- admin panel password, will only be changed after running the init-db job. At first time deployment or after rerunning the job manually. (See docs/manage-py-jobs.md)
       password: geonode
       # -- admin user password
       email: support@example.com

--- a/charts/geonode/values.yaml
+++ b/charts/geonode/values.yaml
@@ -31,9 +31,6 @@ geonode:
   # -- additions to tasks.py init script, must be additional code written in python
   tasks_pre_script: |
     print("tasks_pre_script not defined ...")
-  # -- additions to tasks.py script at the beginning of the tasks.py, must be additional code written in python
-  tasks_post_script: |
-    print("tasks_post_script not defined ...")
 
   accesscontrol:
     # -- Enable/Disable lockdown mode of GeoNode

--- a/docs/manage-py-jobs.md
+++ b/docs/manage-py-jobs.md
@@ -3,7 +3,7 @@ Manage.py Jobs for GeoNode
 This document describes the Kubernetes Job configurations for managing GeoNode tasks such as migrations, static files collection, and fixture loading. These jobs are essential for maintaining and updating your GeoNode instance. With geonode-k8s 1.30.0 and later, these jobs are included by default in the Helm chart.
 
 This jobs are defined in the following files (invoke tasks):
-- `charts/geonode/templates/geonode/jobs/-init-db-job.yaml`
+- `charts/geonode/templates/geonode/jobs/geonode-init-db-job.yaml`
   - run migrations (waitfordbs, migration)
   - insert fixtures (prepare, fixtures)
   - create geoserver store via geserver rest (waitforgeoserver, geoserverfixture)

--- a/docs/manage-py-jobs.md
+++ b/docs/manage-py-jobs.md
@@ -1,0 +1,27 @@
+Manage.py Jobs for GeoNode
+--------------------------
+This document describes the Kubernetes Job configurations for managing GeoNode tasks such as migrations, static files collection, and fixture loading. These jobs are essential for maintaining and updating your GeoNode instance. With geonode-k8s 1.30.0 and later, these jobs are included by default in the Helm chart.
+
+This jobs are defined in the following files (invoke tasks):
+- `charts/geonode/templates/geonode/jobs/-init-db-job.yaml`
+  - run migrations (waitfordbs, migration)
+  - insert fixtures (prepare, fixtures)
+  - create geoserver store via geserver rest (waitforgeoserver, geoserverfixture)
+  - updates geonode admin user password (updateadmin)
+- `charts/geonode/templates/geonode/jobs/geonode-statics-job.yaml`
+  - build statics (initialized, statics)
+
+Each job is configured to run specific management commands using the `invoke` tool, which is a task execution tool used in GeoNode for various administrative tasks.
+This jobs are usually executed automatically during the deployment process, but they can also be run manually if needed. To rerun on of this jobs manually, you have to delete the existing job and create a new one. For example, to rerun the init-db-job job, you can use the following commands:
+```
+# list all jobs
+kubectl get Jobs
+
+# delete the init-db job
+kubectl delete job geonode-geonode--init-db-job
+
+# recreate job
+helm template --values values.yaml -s templates/geonode/jobs/-init-db-job.yaml  charts/geonode/ | kubectl apply -f -
+```
+
+Rerunning a job could be necessary, when updating geonode version.

--- a/docs/manage-py-jobs.md
+++ b/docs/manage-py-jobs.md
@@ -18,7 +18,7 @@ This jobs are usually executed automatically during the deployment process, but 
 kubectl get Jobs
 
 # delete the init-db job
-kubectl delete job geonode-geonode--init-db-job
+kubectl delete job geonode-geonode-init-db-job
 
 # recreate job
 helm template --values values.yaml -s templates/geonode/jobs/-init-db-job.yaml  charts/geonode/ | kubectl apply -f -

--- a/docs/minikube-installation.md
+++ b/docs/minikube-installation.md
@@ -89,22 +89,23 @@ This installation requires to access geonode via "geonode" (or the value in .Val
 kubectl -n geonode get services
 
 NAME                                TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                                 AGE
-service/geonode-geonode             ClusterIP   10.107.192.66    <none>        8000/TCP,8001/TCP                       19m
-service/geonode-geoserver           ClusterIP   10.101.184.88    <none>        8080/TCP                                19m
-service/geonode-memcached           ClusterIP   10.109.197.248   <none>        11211/TCP                               19m
-service/geonode-nginx               ClusterIP   10.97.10.57      <none>        80/TCP                                  19m
-service/geonode-postgres-operator   ClusterIP   10.108.39.88     <none>        8080/TCP                                19m
-service/geonode-postgresql          ClusterIP   10.104.181.46    <none>        5432/TCP                                18m
-service/geonode-postgresql-config   ClusterIP   None             <none>        <none>                                  18m
-service/geonode-postgresql-repl     ClusterIP   10.100.210.207   <none>        5432/TCP                                18m
-service/geonode-rabbitmq            ClusterIP   10.109.132.35    <none>        5672/TCP,4369/TCP,25672/TCP,15672/TCP   19m
-service/geonode-rabbitmq-headless   ClusterIP   None             <none>        4369/TCP,5672/TCP,25672/TCP,15672/TCP   19m
+service/geonode-geonode             ClusterIP   10.108.139.157   <none>        8000/TCP,8001/TCP,5555/TCP              5m19s
+service/geonode-geoserver           ClusterIP   10.109.74.49     <none>        8080/TCP                                5m19s
+service/geonode-memcached           ClusterIP   10.98.114.227    <none>        11211/TCP                               5m19s
+service/geonode-nginx               ClusterIP   10.110.152.86    <none>        80/TCP                                  5m19s
+service/geonode-postgres            ClusterIP   10.108.247.27    <none>        5432/TCP                                5m12s
+service/geonode-postgres-config     ClusterIP   None             <none>        <none>                                  5m2s
+service/geonode-postgres-operator   ClusterIP   10.102.184.20    <none>        8080/TCP                                5m19s
+service/geonode-postgres-repl       ClusterIP   10.108.255.29    <none>        5432/TCP                                5m11s
+service/geonode-pycsw               ClusterIP   10.101.67.39     <none>        8000/TCP                                5m19s
+service/geonode-rabbitmq            ClusterIP   10.110.248.230   <none>        5672/TCP,4369/TCP,25672/TCP,15672/TCP   5m19s
+service/geonode-rabbitmq-headless   ClusterIP   None             <none>        4369/TCP,5672/TCP,25672/TCP,15672/TCP   5m19s
 ```
 
 Find the ip addr of the geonode-nginx service. and add an entry to your hosts file:
 
 ```
-10.97.10.57   geonode.local
+10.110.152.86   geonode.local
 ```
 
 After that the service has to be exposed form minikube. I prefer to use minikube tunnel. Start it via, it will require root access:

--- a/docs/minikube-installation.md
+++ b/docs/minikube-installation.md
@@ -30,53 +30,55 @@ You can check the installtion process with:
 watch kubectl get pods,services,pvc,secrets,postgresql -n geonode
 
 # this will give you an overview over all running pods, services, pvcs,sts and the postgresql class
-NAME                                             READY   STATUS    RESTARTS      AGE
-pod/geonode-geonode-0                            2/2     Running   1 (78s ago)   6m32s
-pod/geonode-geoserver-0                          1/1     Running   0             6m32s
-pod/geonode-memcached-0                          1/1     Running   0             6m32s
-pod/geonode-nginx-b84df5d5c-2vb7m                1/1     Running   5 (31s ago)   6m32s
-pod/geonode-postgres-0                           1/1     Running   0             5m11s
-pod/geonode-postgres-operator-75d5bf84d8-zqcgz   1/1     Running   0             6m32s
-pod/geonode-pycsw-0                              1/1     Running   0             6m32s
-pod/geonode-rabbitmq-0                           1/1     Running   0             6m32s
+NAME                                             READY   STATUS      RESTARTS       AGE
+pod/geonode-geonode-0                            2/2     Running     0              5m19s
+pod/geonode-geonode-init-db-job-dqdhl            0/1     Completed   0              5m19s
+pod/geonode-geonode-statics-job-9lpmk            0/1     Completed   0              5m19s
+pod/geonode-geoserver-0                          1/1     Running     0              5m19s
+pod/geonode-memcached-0                          1/1     Running     0              5m19s
+pod/geonode-nginx-575d4fbc8f-pkj4b               1/1     Running     1 (4m8s ago)   5m19s
+pod/geonode-postgres-0                           1/1     Running     0              5m10s
+pod/geonode-postgres-operator-75d5bf84d8-clfkf   1/1     Running     0              5m19s
+pod/geonode-pycsw-0                              1/1     Running     0              5m19s
+pod/geonode-rabbitmq-0                           1/1     Running     0              5m19s
 
 NAME                                TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                                 AGE
-service/geonode-geonode             ClusterIP   10.103.1.134     <none>        8000/TCP,8001/TCP,5555/TCP              6m32s
-service/geonode-geoserver           ClusterIP   10.110.143.116   <none>        8080/TCP                                6m32s
-service/geonode-memcached           ClusterIP   10.104.83.107    <none>        11211/TCP                               6m32s
-service/geonode-nginx               ClusterIP   10.99.36.115     <none>        80/TCP                                  6m32s
-service/geonode-postgres            ClusterIP   10.102.16.9      <none>        5432/TCP                                5m12s
-service/geonode-postgres-config     ClusterIP   None             <none>        <none>                                  5m5s
-service/geonode-postgres-operator   ClusterIP   10.99.14.191     <none>        8080/TCP                                6m32s
-service/geonode-postgres-repl       ClusterIP   10.103.190.145   <none>        5432/TCP                                5m12s
-service/geonode-pycsw               ClusterIP   10.105.243.111   <none>        8000/TCP                                6m32s
-service/geonode-rabbitmq            ClusterIP   10.111.234.134   <none>        5672/TCP,4369/TCP,25672/TCP,15672/TCP   6m32s
-service/geonode-rabbitmq-headless   ClusterIP   None             <none>        4369/TCP,5672/TCP,25672/TCP,15672/TCP   6m32s
+service/geonode-geonode             ClusterIP   10.108.139.157   <none>        8000/TCP,8001/TCP,5555/TCP              5m19s
+service/geonode-geoserver           ClusterIP   10.109.74.49     <none>        8080/TCP                                5m19s
+service/geonode-memcached           ClusterIP   10.98.114.227    <none>        11211/TCP                               5m19s
+service/geonode-nginx               ClusterIP   10.110.152.86    <none>        80/TCP                                  5m19s
+service/geonode-postgres            ClusterIP   10.108.247.27    <none>        5432/TCP                                5m12s
+service/geonode-postgres-config     ClusterIP   None             <none>        <none>                                  5m2s
+service/geonode-postgres-operator   ClusterIP   10.102.184.20    <none>        8080/TCP                                5m19s
+service/geonode-postgres-repl       ClusterIP   10.108.255.29    <none>        5432/TCP                                5m11s
+service/geonode-pycsw               ClusterIP   10.101.67.39     <none>        8000/TCP                                5m19s
+service/geonode-rabbitmq            ClusterIP   10.110.248.230   <none>        5672/TCP,4369/TCP,25672/TCP,15672/TCP   5m19s
+service/geonode-rabbitmq-headless   ClusterIP   None             <none>        4369/TCP,5672/TCP,25672/TCP,15672/TCP   5m19s
 
 NAME                                              STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
-persistentvolumeclaim/pgdata-geonode-postgres-0   Bound    pvc-a8c32d09-5b03-439b-b77d-2084de13f8dc   2Gi        RWO            standard       5m11s
-persistentvolumeclaim/pvc-geonode-geonode         Bound    pvc-4b141032-08df-4712-883c-1eb2243ff496   2Gi        RWX            standard       6m32s
+persistentvolumeclaim/pgdata-geonode-postgres-0   Bound    pvc-3f7a8ad8-83b5-410a-8b47-6778d97b2b98   2Gi        RWO            standard       5m10s
+persistentvolumeclaim/pvc-geonode-geonode         Bound    pvc-264fdd95-beb6-416a-a7b3-a98834e461bf   2Gi        RWX            standard       5m19s
 
 NAME                                                                    TYPE                 DATA   AGE
-secret/geodata.geonode-postgres.credentials.postgresql.acid.zalan.do    Opaque               2      5m12s
-secret/geonode-geonode-secret                                           Opaque               11     6m32s
-secret/geonode-geoserver-secret                                         Opaque               6      6m32s
-secret/geonode-rabbitmq                                                 Opaque               2      6m32s
-secret/geonode-rabbitmq-config                                          Opaque               1      6m32s
-secret/geonode.geonode-postgres.credentials.postgresql.acid.zalan.do    Opaque               2      5m12s
-secret/postgres.geonode-postgres.credentials.postgresql.acid.zalan.do   Opaque               2      5m12s
-secret/sh.helm.release.v1.geonode.v1                                    helm.sh/release.v1   1      6m32s
-secret/sh.helm.release.v1.geonode.v2                                    helm.sh/release.v1   1      5m12s
-secret/standby.geonode-postgres.credentials.postgresql.acid.zalan.do    Opaque               2      5m11s
+secret/geodata.geonode-postgres.credentials.postgresql.acid.zalan.do    Opaque               2      53d
+secret/geonode-geonode-secret                                           Opaque               12     5m19s
+secret/geonode-geoserver-secret                                         Opaque               6      5m19s
+secret/geonode-rabbitmq                                                 Opaque               2      5m19s
+secret/geonode-rabbitmq-config                                          Opaque               1      5m19s
+secret/geonode.geonode-postgres.credentials.postgresql.acid.zalan.do    Opaque               2      53d
+secret/postgres.geonode-postgres.credentials.postgresql.acid.zalan.do   Opaque               2      53d
+secret/sh.helm.release.v1.geonode.v1                                    helm.sh/release.v1   1      5m19s
+secret/standby.geonode-postgres.credentials.postgresql.acid.zalan.do    Opaque               2      53d
 
 NAME                                        TEAM      VERSION   PODS   VOLUME   CPU-REQUEST   MEMORY-REQUEST   AGE     STATUS
-postgresql.acid.zalan.do/geonode-postgres   geonode   15        1      2Gi                                     5m12s   Running
+postgresql.acid.zalan.do/geonode-postgres   geonode   15        1      2Gi      100m          0.5Gi            5m19s   Running
 ```
 
 The initial start takes some time, due to init process of the django application. You can check the status via:
 ```bash
 kubectl -n geonode logs pod/geonode-geonode-0 -f 
 ```
+Furhter check that the `geonode-geonode-init-db-job` jobs is finished as this is setting the admin user password.
 
 ## Expose Service to outside world
 


### PR DESCRIPTION
## Description
To optimize start time of the geonode container, this PR moves initialization tasks into individual k8s.jobs:
- `charts/geonode/templates/geonode/jobs/geonode-init-db-job.yaml`
  - run migrations (waitfordbs, migration)
  - insert fixtures (prepare, fixtures)
  - create geoserver store via geserver rest (waitforgeoserver, geoserverfixture)
  - updates geonode admin user password (updateadmin)
- `charts/geonode/templates/geonode/jobs/geonode-statics-job.yaml`
  - build statics (initialized, statics)

This jobs only running once at initial chart deployment. To rerun this jobs, maybe after geonode upgrade, this PR adds docs including a howto rerun jobs.

## Type of Change

Please select the relevant option:

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [x] Refactoring
- [ ] Other (please describe)

## Related Issue

If there is an existing issue related to this pull request, please reference it here.

closes #251 

## Checklist

Please ensure that your pull request meets the following requirements:

- The pull request is limited to one type (docs, feature, bug fix, etc.)
- The pull request is as small as possible. Consider opening multiple pull requests instead of one large one.
- The feature or bug fix has been discussed and documented in an issue beforehand.

## Additional Notes

Any additional information or context regarding the pull request can be provided here.

Thank you for creating this pull request