### PR TITLE
Provide option to import certificates into Geoservers Trust Store

### DIFF
--- a/charts/geonode/README.md
+++ b/charts/geonode/README.md
@@ -155,6 +155,7 @@ Helm Chart for Geonode. Supported versions: Geonode: 5.1.0, Geoserver: 2.28.4-la
 | geonode.uwsgi.worker_reload_mercy | int | `60` | How long to wait before forcefully killing workers |
 | geonode.version | string | `"5.1.0"` | GeoNode version used for chart-side version gating (env var names, defaults). Must be kept in sync with `geonode.image.tag`. Non-semver values (e.g. "latest", sha digest pins) fall back to newest-version behavior. |
 | geonodeFixtures | map of fixture files | `nil` | Fixture files which shall be made available under /usr/src/geonode/geonode/fixtures (refer to https://docs.djangoproject.com/en/4.2/howto/initial-data/) |
+| geoserver.caConfigMap | string | empty | Optional; name for a ConfigMap. If provided, the ConfigMap will be interpretated as certificates to be added to the Java Trust Store |
 | geoserver.container_name | string | `"geoserver"` | geoserver container name |
 | geoserver.force_reinit | bool | `true` | set force reinit true so that changing passwords etc. in Values.yaml will take effect after restarting the pod this on the other hand will increase pod initializing time, only change if you know what you are doing |
 | geoserver.image.name | string | `"geonode/geoserver"` | geoserver image docker image |

--- a/charts/geonode/templates/geoserver/geoserver-deploy.yaml
+++ b/charts/geonode/templates/geoserver/geoserver-deploy.yaml
@@ -102,6 +102,66 @@ spec:
         - name: gs-tmp
           mountPath: /seed-tmp
 
+{{- if .Values.geoserver.caConfigMap }}
+      # initContainer to import internal CA into the Java-Truststore (the JVM does not use the OS-store, only its own cacerts).
+      # To support a read-only setup, create a copy in an emptyDir and point to it with JAVA_TOOL_OPTIONS.
+      - name: trust-internal-ca
+        securityContext:
+          runAsNonRoot: {{- if hasKey $gsctx "runAsNonRoot" }} {{ $gsctx.runAsNonRoot }} {{- else }} true {{- end }}
+          runAsUser: {{- if hasKey $gsctx "runAsUser" }} {{ $gsctx.runAsUser }} {{- else }} {{ .Values.global.securityContext.runAsUser }} {{- end }}
+          runAsGroup: {{- if hasKey $gsctx "runAsGroup" }} {{ $gsctx.runAsGroup }} {{- else }} {{ .Values.global.securityContext.runAsGroup }} {{- end }}
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        image: "{{ .Values.geoserver.image.name }}:{{ .Values.geoserver.image.tag }}"
+        imagePullPolicy: {{ .Values.geoserver.imagePullPolicy }}
+        command:
+        - sh
+        - -c
+        - |
+          set -eu
+
+          SRC="${JAVA_HOME}/lib/security/cacerts"
+          [ -f "$SRC" ] || SRC="${JAVA_HOME}/jre/lib/security/cacerts"   # Java 8
+          [ -f "$SRC" ] || { echo "!! cacerts not found (JAVA_HOME=${JAVA_HOME:-unset})"; exit 1; }
+          echo ">> Base truststore: $SRC"
+          cp "$SRC" /truststore/cacerts
+          chmod 0600 /truststore/cacerts
+
+          # Collect all ConfigMap certificate entries
+          rm -rf /truststore/split
+          mkdir -p /truststore/split
+          cat /ca/* > /truststore/all.pem
+          awk 'BEGIN{c=0} /BEGIN CERTIFICATE/{c++} c>0 {print > ("/truststore/split/ca-" c ".pem")}' /truststore/all.pem
+
+          n=0
+          for f in /truststore/split/ca-*.pem; do
+            [ -f "$f" ] || continue
+            n=$((n+1))
+            echo ">> Importing certificate $n"
+            keytool -importcert -noprompt -trustcacerts \
+              -alias "internal-ca-${n}" \
+              -file "$f" \
+              -keystore /truststore/cacerts \
+              -storepass changeit
+          done
+          rm -rf /truststore/split /truststore/all.pem
+
+          [ "$n" -gt 0 ] || { echo "!! No certificates found in the ConfigMap"; exit 1; }
+          echo ">> Now contained in truststore:"
+          keytool -list -keystore /truststore/cacerts -storepass changeit | grep -i "internal-ca"
+        volumeMounts:
+        - name: gs-truststore
+          mountPath: /truststore
+        - name: internal-ca
+          mountPath: /ca
+          readOnly: true
+{{- end }}
+
 {{- if not (empty .Values.geoserver.imagePullSecret) }}
       imagePullSecrets:
       - name: {{ .Values.geoserver.imagePullSecret }}
@@ -138,6 +198,11 @@ spec:
               secretKeyRef:
                 name: {{ include "database_geodata_password_secret_key_ref" . }}
                 key: {{ include "database_geodata_password_key_ref" . }}
+          {{- if .Values.geoserver.caConfigMap }}
+          # Override truststore; be sure to use JAVA_TOOL_OPTIONS and not JAVA_OPTS, to avoid breaking other options from env-ConfigMap.
+          - name: JAVA_TOOL_OPTIONS
+            value: "-Djavax.net.ssl.trustStore=/truststore/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
+          {{- end }}
           {{- with .Values.geoserver.extraPodEnv }}
           {{- tpl . $ | nindent 10 }}
           {{- end }}
@@ -159,6 +224,11 @@ spec:
           mountPath: /usr/local/tomcat/logs
         - name: tmp
           mountPath: /tmp
+        {{- if .Values.geoserver.caConfigMap }}
+        - name: gs-truststore
+          mountPath: /truststore
+          readOnly: true
+        {{- end }}
         
         {{- with .Values.geoserver.startupProbe }}
         startupProbe:
@@ -177,6 +247,13 @@ spec:
       - name: geoserver-printing-config-yaml
         configMap:
           name: {{ .Release.Name }}-geoserver-printing-config-yaml
+      {{- if .Values.geoserver.caConfigMap }}
+      - name: internal-ca
+        configMap:
+          name: {{ .Values.geoserver.caConfigMap }}
+      - name: gs-truststore
+        emptyDir: {}
+      {{- end }}
       - name: pvc-geoserver-data
         persistentVolumeClaim:
           claimName: {{ include "pvc_geoserver_data_name" . }}

--- a/charts/geonode/values.yaml
+++ b/charts/geonode/values.yaml
@@ -546,6 +546,12 @@ geoserver:
     failureThreshold: 3
     timeoutSeconds: 5
 
+  # -- point to a ConfigMap containing one or more PEM-certificates of CA-certificates to be imported into the Java TrustStore. 
+  # -- Needed to support https service calls (such as WMS) to servers whose certificate was not signed by a CA already bundled in the standard Java TrustStore.
+  # -- (including calls from the print container to your GeoNode).
+  # caConfigMap: "ca-cert.pem"
+
+
 geoserver_data:
   container_name: geoserver-data-dir
   image:


### PR DESCRIPTION
## Description

Provide option to import certificates from a ConfigMap into the Java Trust Store of Geoserver. This is needed specifically for JVM containers, because the JVM does not use certificates from the underlying OS, only publicly known ones are bundled within the JVM by default.

## Type of Change

Please select the relevant option:

- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Related Issue

closes #283 

My understanding is that this pull request addresses the main point of issue #283. Because no follow-up pull request was provided for #283, I propose this pull request to close it.